### PR TITLE
change(nu5): bump version and protocol version

### DIFF
--- a/zcash/client.go
+++ b/zcash/client.go
@@ -40,7 +40,7 @@ var defaultPeerConfig = &peer.Config{
 	// TODO: fork https://github.com/gtank/btcd/blob/master/peer/peer.go
 	//       and set MinAcceptableProtocolVersion based on the most recently activated network upgrade
 	//       see ticket #10 for details
-	ProtocolVersion: 170100, // Zcash NU5 mainnet with addrv2
+	ProtocolVersion: 170100, // Zcash NU5 mainnet
 }
 
 var (

--- a/zcash/client.go
+++ b/zcash/client.go
@@ -28,7 +28,7 @@ var (
 
 var defaultPeerConfig = &peer.Config{
 	UserAgentName:    "zfnd-seeder",
-	UserAgentVersion: "0.1.3-alpha.3",
+	UserAgentVersion: "0.1.3-alpha.4",
 	ChainParams:      nil,
 	Services:         0,
 	TrickleInterval:  time.Second * 10,
@@ -40,7 +40,7 @@ var defaultPeerConfig = &peer.Config{
 	// TODO: fork https://github.com/gtank/btcd/blob/master/peer/peer.go
 	//       and set MinAcceptableProtocolVersion based on the most recently activated network upgrade
 	//       see ticket #10 for details
-	ProtocolVersion: 170017, // Zcash NU5 mainnet with addrv2
+	ProtocolVersion: 170100, // Zcash NU5 mainnet with addrv2
 }
 
 var (


### PR DESCRIPTION
Bump version and protocol version for the new NU5 mainnet values, per https://github.com/ZcashFoundation/zebra/issues/3458

https://github.com/ZcashFoundation/zebra/issues/3458 mentions "maximum network protocol version" but I don't think that exists here? There's the minimum (#10) but that doesn't seem required for now.