### PR TITLE
filter peers using non-std ports

### DIFF
--- a/zcash/address_book.go
+++ b/zcash/address_book.go
@@ -224,7 +224,7 @@ func (bk *AddressBook) waitForAddresses(n int, done chan struct{}) {
 
 // GetAddressList returns a slice of n valid addresses in random order.
 // If there aren't enough known addresses, it returns as many as we have.
-func (bk *AddressBook) shuffleAddressList(n int, v6 bool) []net.IP {
+func (bk *AddressBook) shuffleAddressList(n int, v6 bool, defaultPort string) []net.IP {
 	bk.addrState.RLock()
 	defer bk.addrState.RUnlock()
 
@@ -243,6 +243,13 @@ func (bk *AddressBook) shuffleAddressList(n int, v6 bool) []net.IP {
 
 		if !v6 && v.netaddr.IP.To4() == nil {
 			// skip IPv6 addresses if we're asked for v4
+			continue
+		}
+
+		if strconv.Itoa(int(v.netaddr.Port)) != defaultPort {
+			// The DNS seeder is only able to return IP addresses, and it can't report
+			// ports. For this reason, we can only return addresses that are using
+			// the standard port.
 			continue
 		}
 

--- a/zcash/client.go
+++ b/zcash/client.go
@@ -543,12 +543,12 @@ func (s *Seeder) Ready() bool {
 
 // Addresses returns a slice of n IPv4 addresses or as many as we have if it's less than that.
 func (s *Seeder) Addresses(n int) []net.IP {
-	return s.addrBook.shuffleAddressList(n, false)
+	return s.addrBook.shuffleAddressList(n, false, s.GetNetworkDefaultPort())
 }
 
 // AddressesV6 returns a slice of n IPv6 addresses or as many as we have if it's less than that.
 func (s *Seeder) AddressesV6(n int) []net.IP {
-	return s.addrBook.shuffleAddressList(n, true)
+	return s.addrBook.shuffleAddressList(n, true, s.GetNetworkDefaultPort())
 }
 
 // GetPeerCount returns how many valid peers we know about.


### PR DESCRIPTION
We list all crawled IPs, but some of them use non-standard ports. But clients have no way to know what are the port of the peers, so we must only list ones using default ports.

I did the simplest thing that worked which is filtering at the last possible moment, when the seeder is queried. Since the current implementation is not particularly optimized (it iterates all the peers and shuffles them), this seems OK for now.

Closes https://github.com/ZcashFoundation/zebra/issues/4547