### PR TITLE
Skip peers using non-std ports before adding to queue

### DIFF
--- a/zcash/client_callbacks.go
+++ b/zcash/client_callbacks.go
@@ -58,7 +58,10 @@ func (s *Seeder) onAddr(p *peer.Peer, msg *wire.MsgAddr) {
 			s.logger.Printf("Already knew about %s:%d", na.IP, na.Port)
 			continue
 		}
-		s.addrQueue <- na
+		_, denied := DeniedPorts[na.Port]
+		if !denied {
+			s.addrQueue <- na
+		}
 	}
 }
 
@@ -84,7 +87,10 @@ func (s *Seeder) onAddrV2(p *peer.Peer, msg *wire.MsgAddrV2) {
 				s.logger.Printf("Already knew about %s:%d", na.IP, na.Port)
 				continue
 			}
-			s.addrQueue <- &na.NetAddress
+			_, denied := DeniedPorts[na.Port]
+			if !denied {
+				s.addrQueue <- &na.NetAddress
+			}
 		}
 	}
 }


### PR DESCRIPTION
In #17 we avoided connecting to peers using flux ports. However the crawl was too slow (~13 hours?). I added the skip logic to when the addresses are returned by peers, before adding them to the queue, which makes crawling much faster (~5 min). (Not totally sure why. Are Go channels _that_ slow? :thinking: )

I tried block those addresses, but thinking about it, it does not seem to be the correct approach, since zcashd nodes can still conect to flux peers (i.e. just because a peer return peers using flux ports, it does not mean that peer is bad).